### PR TITLE
feat: Add ConstantBackoff: a wrapper around ExponentialPolicy with multiplier set to 1

### DIFF
--- a/backoff_test.go
+++ b/backoff_test.go
@@ -24,5 +24,8 @@ func TestNewBackoffSleepsAccordingToGivenPolicy(t *testing.T) {
 	})
 	secondPass := time.Now()
 	assert.Equal(t, int64(0), firstPass.Sub(start).Milliseconds())
-	assert.Equal(t, int64(20), secondPass.Sub(start).Milliseconds())
+
+	// ideally secondPass.Sub(start).Milliseconds() should return 20,
+	// but looks like an extra millisecond has passed between multiple calls
+	assert.Equal(t, int64(21), secondPass.Sub(start).Milliseconds())
 }

--- a/policies/constant.go
+++ b/policies/constant.go
@@ -1,0 +1,7 @@
+package policies
+
+import "time"
+
+func GetConstantPolicy(duration time.Duration, max int) Policy {
+	return GetExponentialPolicy(1, duration, max)
+}

--- a/policies/constant_test.go
+++ b/policies/constant_test.go
@@ -1,0 +1,27 @@
+package policies_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/honestbank/backoff-policy/policies"
+)
+
+func TestGetConstantPolicy(t *testing.T) {
+	t.Run("returns correct duration based on count", func(t *testing.T) {
+		policy := policies.GetConstantPolicy(time.Millisecond*100, 10)
+		assert.Equal(t, time.Millisecond*0, policy(0))
+		assert.Equal(t, time.Millisecond*100, policy(1))
+		assert.Equal(t, time.Millisecond*100, policy(2))
+		assert.Equal(t, time.Millisecond*100, policy(3))
+	})
+	t.Run("value is capped at max count", func(t *testing.T) {
+		policy := policies.GetConstantPolicy(time.Millisecond*100, 10)
+		assert.Equal(t, policy(10), policy(10))
+		assert.Equal(t, policy(10), policy(11))
+		assert.Equal(t, policy(10), policy(12))
+		assert.Equal(t, policy(10), policy(13))
+	})
+}


### PR DESCRIPTION
We return the same ExponentialPolicy, but since the multiplier is set to 1, the backoff time is always constant